### PR TITLE
Fix errors when compiling on newer compilers (prototype definitions fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ STRIP = strip
 CC ?= cc
 CFLAGS += -I$(DEP)/include -I$(SRC)/include -I$(SRC)
 CFLAGS += -Wall -Wextra -DPALERAIN_VERSION=\"2.0.0\" -Wall -Wextra -Wno-unused-parameter
-CFLAGS += -Wno-unused-variable -I$(SRC)/src -std=c99 -pedantic-errors -D_C99_SOURCE -D_POSIX_C_SOURCE=200112L -D_DARWIN_C_SOURCE
+CFLAGS += -Wno-unused-variable -I$(SRC)/src -std=c99 -pedantic-errors -D_C99_SOURCE -D_POSIX_C_SOURCE=200112L -D_DARWIN_C_SOURCE -lc
 LIBS += $(DEP)/lib/libimobiledevice-1.0.a $(DEP)/lib/libirecovery-1.0.a $(DEP)/lib/libusbmuxd-2.0.a
 LIBS += $(DEP)/lib/libimobiledevice-glue-1.0.a $(DEP)/lib/libplist-2.0.a -pthread
 ifeq ($(TARGET_OS),)
@@ -21,7 +21,7 @@ LDFLAGS += -Wl,-dead_strip
 LIBS += -framework CoreFoundation -framework IOKit
 else
 CFLAGS += -fdata-sections -ffunction-sections
-LDFLAGS += -static -no-pie -Wl,--gc-sections
+LDFLAGS += -static -no-pie -Wl,--gc-sections -lc
 endif
 LIBS += $(DEP)/lib/libmbedtls.a $(DEP)/lib/libmbedcrypto.a $(DEP)/lib/libmbedx509.a $(DEP)/lib/libreadline.a
 

--- a/include/palerain.h
+++ b/include/palerain.h
@@ -186,7 +186,7 @@ void devinfo_free(devinfo_t *dev);
 bool cpid_is_arm64(unsigned int cpid);
 /* devhelper commands */
 int subscribe_cmd(usbmuxd_event_cb_t device_event_cb, irecv_device_event_cb_t irecv_event_cb);
-int unsubscribe_cmd();
+int unsubscribe_cmd(void);
 int devinfo_cmd(devinfo_t *dev, const char *udid);
 int enter_recovery_cmd(const char* udid);
 int reboot_cmd(const char* udid);
@@ -195,7 +195,7 @@ int recvinfo_cmd(recvinfo_t* info, const uint64_t ecid);
 int autoboot_cmd(const uint64_t ecid);
 int exitrecv_cmd(const uint64_t ecid);
 
-int exec_checkra1n();
+int exec_checkra1n(void);
 int override_file(override_file_t *finfo, niarelap_file_t** orig, unsigned int *orig_len, char *filename);
 void* pongo_helper(void* ptr);
 
@@ -203,25 +203,25 @@ void* pongo_helper(void* ptr);
 extern void* pongo_usb_callback(void* arg);
 usb_ret_t USBControlTransfer(usb_device_handle_t handle, uint8_t bmRequestType, uint8_t bRequest, uint16_t wValue, uint16_t wIndex, uint32_t wLength, void *data, uint32_t *wLenDone);
 const char *usb_strerror(usb_ret_t err);
-int wait_for_pongo();
-int issue_pongo_command();
-int upload_pongo_file();
-int tui();
+int wait_for_pongo(void);
+int upload_pongo_file(usb_device_handle_t, unsigned char*, unsigned int);
+int issue_pongo_command(usb_device_handle_t, char*);
+int tui(void);
 int optparse(int argc, char* argv[]);
 
-bool get_spin();
+bool get_spin(void);
 bool set_spin(bool val);
-bool get_found_pongo();
+bool get_found_pongo(void);
 void* pongo_helper(void* _);
 bool set_found_pongo(bool val);
-uint64_t get_ecid_wait_for_dfu();
+uint64_t get_ecid_wait_for_dfu(void);
 uint64_t set_ecid_wait_for_dfu(uint64_t ecid);
 
 void write_stdout(char *buf, uint32_t len);
 void io_start(stuff_t *stuff);
 void io_stop(stuff_t *stuff);
 
-void print_credits();
+void print_credits(void);
 
 #ifdef DEV_BUILD
 #include <newt.h>

--- a/src/credits.c
+++ b/src/credits.c
@@ -6,7 +6,7 @@
 #define THE_PLUSH "Ploosh"
 
 #define T void
-#define R print_credits() {
+#define R print_credits(void) {
 #define O fprintf
 #define U (
 #define B stdout

--- a/src/devhelper.c
+++ b/src/devhelper.c
@@ -93,7 +93,7 @@ int subscribe_cmd(usbmuxd_event_cb_t device_event_cb, irecv_device_event_cb_t ir
 	return 0;
 }
 
-int unsubscribe_cmd()
+int unsubscribe_cmd(void)
 {
 	usbmuxd_events_unsubscribe(usbmuxdctx);
 	irecv_device_event_unsubscribe(irecvctx);

--- a/src/exec_checkra1n.c
+++ b/src/exec_checkra1n.c
@@ -30,7 +30,7 @@ char* ext_checkra1n = NULL;
 
 #define tmpdir getenv("TMPDIR") == NULL ? "/tmp" : getenv("TMPDIR")
 
-int exec_checkra1n() {
+int exec_checkra1n(void) {
 	LOG(LOG_INFO, "About to execute checkra1n");
 	int fd, ret;
 	char* checkra1n_path = NULL;

--- a/src/lock_vars.c
+++ b/src/lock_vars.c
@@ -55,7 +55,7 @@ static bool set_locked_bool(bool* val, bool newval, pthread_mutex_t* mutex) {
     return newval;
 }
 
-bool get_spin() {
+bool get_spin(void) {
     return get_locked_bool(&spin, &spin_mutex);
 }
 
@@ -63,7 +63,7 @@ bool set_spin(bool newval) {
     return set_locked_bool(&spin, newval, &spin_mutex);
 }
 
-bool get_found_pongo() {
+bool get_found_pongo(void) {
    return get_locked_bool(&found_pongo, &found_pongo_mutex);
 }
 
@@ -71,7 +71,7 @@ bool set_found_pongo(bool val) {
     return set_locked_bool(&found_pongo, val, &found_pongo_mutex);
 }
 
-uint64_t get_ecid_wait_for_dfu() {
+uint64_t get_ecid_wait_for_dfu(void) {
     LOG(LOG_VERBOSE5, "locking ecid wait for dfu mutex for get");
     pthread_mutex_lock(&ecid_dfu_wait_mutex);
     uint64_t ret = ecid_wait_for_dfu;

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,6 @@
 #include <signal.h>
 #include <pthread.h>
 #include <inttypes.h>
-#include <getopt.h>
 #include <errno.h>
 #include <spawn.h>
 #include <sys/mman.h>
@@ -56,7 +55,7 @@ void thr_cleanup(void* ptr) {
 	*(int*)ptr = 0;
 }
 
-int build_checks() {
+int build_checks(void) {
 #if defined(__APPLE__)
 #ifndef NO_CHECKRAIN
 	struct mach_header_64* c1_header = (struct mach_header_64*)&checkra1n[0];


### PR DESCRIPTION
This adds "void" into the necessary places and fixes prototypes in others that were returning errors